### PR TITLE
Give Blueprint modules access to all namespaces

### DIFF
--- a/android/namespace.go
+++ b/android/namespace.go
@@ -228,6 +228,11 @@ func (r *NameResolver) parseFullyQualifiedName(name string) (namespaceName strin
 }
 
 func (r *NameResolver) getNamespacesToSearchForModule(sourceNamespace *Namespace) (searchOrder []*Namespace) {
+	if sourceNamespace.visibleNamespaces == nil {
+		// When handling dependencies before namespaceMutator, assume they are non-Soong Blueprint modules and give
+		// access to all namespaces.
+		return r.sortedNamespaces.sortedItems()
+	}
 	return sourceNamespace.visibleNamespaces
 }
 


### PR DESCRIPTION
Don't enforce namespaces on Blueprint modules like
bootstrap_go_package, their dependencies are handled before
namespaces are initialized in namespaceMutator.

Fixes: 135246048
Test: TestDependingOnBlueprintModuleInRootNamespace
Change-Id: I7cf1c26bb8512eed59d6b4eb42a49f7080ffa281